### PR TITLE
Move babel-polyfill to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "npm": ">=4.0"
   },
   "dependencies": {
+    "babel-polyfill": "^6.23.0",
     "common-path-prefix": "^1.0.0",
     "mkdirp": "^0.5.1",
     "prettier": "^1.3.1",
@@ -49,7 +50,6 @@
     "babel-eslint": "^6.1.2",
     "babel-plugin-syntax-flow": "^6.18.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-preset-es2017": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",


### PR DESCRIPTION
For the https://github.com/uber-node/thrift2flow/issues/2