### PR TITLE
Enums and  binary support implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift2flow",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Convert Thrift definitions to Flowtype declarations",
   "homepage": "https://github.com/uber-node/thrift2flow",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift2flow",
-  "version": "0.2.6",
+  "version": "0.2.4",
   "description": "Convert Thrift definitions to Flowtype declarations",
   "homepage": "https://github.com/uber-node/thrift2flow",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift2flow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Convert Thrift definitions to Flowtype declarations",
   "homepage": "https://github.com/uber-node/thrift2flow",
   "bugs": {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -40,6 +40,7 @@ import {ThriftFileConverter} from './convert';
 const argv = yargs
   .usage('Usage: $0 [options] <thrift files..>')
   .option('suffix', {describe: 'appended to generated type names', default: 'Type'})
+  .option('enumvalues', {describe: 'use enum values type (number)', default: false})
   .help('h')
   .alias('h', 'help').argv;
 
@@ -53,7 +54,11 @@ if (!thriftPaths.length) {
 const allOutput = {};
 
 for (const thriftPath of thriftPaths) {
-  const converter = new ThriftFileConverter(thriftPath, name => name + argv.suffix);
+  const converter = new ThriftFileConverter(
+    thriftPath,
+    name => name + argv.suffix,
+    argv.enumvalues
+  );
   converter
     .getImportAbsPaths()
     .filter(p => thriftPaths.indexOf(p) === -1)

--- a/src/main/types.js
+++ b/src/main/types.js
@@ -28,6 +28,7 @@ import {BaseType, ListType, MapType, SetType} from 'thriftrw/ast';
 
 export class TypeConverter {
   static primitives = {
+    binary: 'Buffer',
     bool: 'boolean',
     byte: 'number',
     i8: 'number',

--- a/src/test/enums.spec.js
+++ b/src/test/enums.spec.js
@@ -64,3 +64,42 @@ function go(s : MyStructXXX, t: EnumTypedefXXX) {
     }
   )
 );
+
+test(
+  'enums values',
+  flowResultTest(
+    {
+      // language=thrift
+      'types.thrift': `
+typedef MyEnum EnumTypedef
+
+enum MyEnum {
+  OK = 1
+  ERROR = 2
+}
+
+struct MyStruct {
+  1: MyEnum f_MyEnum
+  2: EnumTypedef f_EnumTypedef
+}
+`,
+      // language=JavaScript
+      'index.js': `
+// @flow
+import type {MyStructXXX,EnumTypedefXXX,MyEnumXXXKeys} from './types';
+
+function go(s : MyStructXXX, t: EnumTypedefXXX, k: MyEnumXXXKeys) {
+  const values : number[] = [s.f_MyEnum, s.f_EnumTypedef, t];
+  const keys : MyEnumXXXKeys = 'OK';
+  return [values, keys];
+}
+`
+    },
+    (t: Test, r: FlowResult) => {
+      t.deepEqual(r.errors, []);
+      t.end();
+    },
+    'XXX',
+    true
+  )
+);

--- a/src/test/primitives.spec.js
+++ b/src/test/primitives.spec.js
@@ -42,6 +42,7 @@ const primitiveStruct = `
     8: string f_string
     9: optional string f_optional
     10: optional string f_default = "hello"
+    11: binary f_binary
   }
 `;
 
@@ -57,11 +58,11 @@ import type {PrimitivesXXX} from './types';
 
 function go(s : PrimitivesXXX) {
   const numbers : number[] = [s.f_byte, s.f_i8, s.f_i16, s.f_i32, s.f_double];
-  const buffer: Buffer = s.f_i64;
+  const buffers : Buffer[] = [s.f_i64, s.f_binary];
 
   const booleans : boolean[] = [s.f_boolean];
   const strings : string[] = [s.f_string];
-  return [numbers, booleans, strings];
+  return [numbers, booleans, strings, buffers];
 }
 `
     },

--- a/src/test/util.js
+++ b/src/test/util.js
@@ -38,7 +38,8 @@ import {ThriftFileConverter} from '../main/convert';
 export const flowResultTest = (
   files: {[string]: string},
   testFn: (Function, FlowResult) => void,
-  suffix: string = 'XXX'
+  suffix: string = 'XXX',
+  enumvalues: boolean = false
 ) => (t: Test) => {
   const root = tmp.dirSync().name;
   const paths = Object.keys(files);
@@ -49,7 +50,7 @@ export const flowResultTest = (
     .forEach(p =>
       fs.writeFileSync(
         p.replace(/\.thrift$/, '.js'),
-        new ThriftFileConverter(p, name => name + suffix).generateFlowFile()
+        new ThriftFileConverter(p, name => name + suffix, enumvalues).generateFlowFile()
       )
     );
   fs.writeFileSync(path.resolve(root, '.flowconfig'), `[libs]


### PR DESCRIPTION
    Added support for 'binary' thrift type.
    Added support for different Enums definition types generation to support data deserialized using NODE JS standard thrift compiler.

    By default Enum type will be generated as
    export type MyEnum = "TEST1" | "TEST2"
    export type MyEnumValues = number;

    if enumvalues cmd line argument set to true, then
    export type MyEnum = number;
    export type MyEnumKeys = "TEST1" | "TEST2";