### PR TITLE
[bug] Consts should not have suffix

### DIFF
--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -125,7 +125,7 @@ export class ThriftFileConverter {
   generateConst = (def: Const) => {
     // string values need to be in quotes
     const value = typeof def.value.value === 'string' ? `'${def.value.value}'` : def.value.value;
-    return `export const ${this.transformName(def.id.name)}: ${this.types.convert(def.fieldType)} = ${value};`;
+    return `export const ${def.id.name}: ${this.types.convert(def.fieldType)} = ${value};`;
   }
 
   generateStruct = ({id: {name}, fields}: Struct) =>

--- a/src/test/consts.spec.js
+++ b/src/test/consts.spec.js
@@ -54,16 +54,16 @@ struct MyStruct {
       'index.js': `
 // @flow
 import type {MyStructXXX, StatusXXX, ScoreXXX} from './types';
-import {NOT_ELIGIBLEXXX, STATUS_ELIGIBLE_LITERALXXX, MIN_SCOREXXX, MAX_SCOREXXX} from './types';
+import {NOT_ELIGIBLE, STATUS_ELIGIBLE_LITERAL, MIN_SCORE, MAX_SCORE} from './types';
 
 function go(s : MyStructXXX): Array<string | number> {
   const values = [s.f_status];
 
-  if (s.otherStatus) {
+  if (s.f_otherStatus) {
     values.push(s.f_otherStatus);
   }
 
-  if (s.f_score >= MIN_SCOREXXX && s.f_score < MAX_SCOREXXX) {
+  if (s.f_score >= MIN_SCORE && s.f_score < MAX_SCORE) {
     values.push(s.f_score);
   }
 


### PR DESCRIPTION
It doesn't make sense for exported const values to have a suffix, since they are actual VALUES and not types.

Previous behavior:

```thrift
const string STATUS_ELIGIBLE = 'eligible'
```

==>

```js
export const STATUS_ELIGIBLEType: string = 'eligible';
```